### PR TITLE
feat: rename project and preparing release

### DIFF
--- a/.metwork-framework/README.md
+++ b/.metwork-framework/README.md
@@ -2,10 +2,16 @@
 
 A cron job wrapper to add some missing features (locks, timeouts, random sleeps, env loading...).
 
+
+## Setup
+```shell
+pip install cron-wrapper
+```
+
 ## Usage
 
 ```
-Usage: cronwrap.py [options]
+Usage: cronwrap [options]
 
 Options:
   -h, --help            show this help message and exit
@@ -37,7 +43,7 @@ Options:
 In a user `crontab`:
 
 ```
-*/10 * * * * cronwrap.py --load-env --lock --low -- slow_cleaning_command.sh slow_cleaning_command_option
+*/10 * * * * cronwrap --load-env --lock --low -- slow_cleaning_command.sh slow_cleaning_command_option
 ```
 
 to run `slow_cleaning_command.sh slow_cleaning_command_option` every 10 minutes but with:

--- a/Makefile
+++ b/Makefile
@@ -8,12 +8,12 @@ install: all
 
 clean:
 	rm -f *.pyc
-	cd tests && rm -f *.pyc
-	cd cronwrapper && rm -f *.pyc
+	rm -f tests/*.pyc
 	rm -f MANIFEST
 	rm -Rf build
 	rm -Rf dist
 	rm -Rf cronwrapper.egg-info
+	rm -Rf cronwrapper/*.pyc
 	rm -Rf cronwrapper/__pycache__
 	rm -Rf tests/__pycache__
 	rm -f tests/conf.py

--- a/cronwrapper/cronwrap.py
+++ b/cronwrapper/cronwrap.py
@@ -189,8 +189,8 @@ def main():
     if args.lock:
         command_hash = hashlib.md5(command.encode('utf8')).hexdigest()
         lock_path = os.path.join(tempfile.gettempdir(),
-                                 "cronwrapper_%i_%s.lock" % (os.getuid(),
-                                                             command_hash))
+                                 "cron-wrapper_%i_%s.lock" % (os.getuid(),
+                                                              command_hash))
         lock = FileLock(lock_path, timeout=1)
     else:
         lock = DummyContextManager()

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# This file is part of cronwrapper utility released under the MIT license.
+# This file is part of `cron-wrapper` utility released under the MIT license.
 # See the LICENSE file for more information.
 
 from setuptools import setup, find_packages
@@ -16,14 +16,14 @@ with open('pip-requirements.txt') as reqs:
     ]
 
 setup(
-    name='cronwrapper',
-    version="0.0.1",
+    name='cron-wrapper',
+    version="0.1.0",
     author="Fabien MARTY",
     author_email="fabien.marty@gmail.com",
-    url="https://github.com/metwork-framework/cronwrapper",
+    url="https://github.com/metwork-framework/cron-wrapper",
     packages=find_packages(),
     license='MIT',
-    download_url='https://github.com/metwork-framework/cronwrapper',
+    download_url='https://github.com/metwork-framework/cron-wrapper',
     description=DESCRIPTION,
     long_description=LONG_DESCRIPTION,
     install_requires=install_requires,
@@ -31,7 +31,9 @@ setup(
         'Development Status :: 4 - Beta',
         'Environment :: Console',
         'Intended Audience :: Developers',
+        'Intended Audience :: Science/Research',
         'Intended Audience :: System Administrators',
+        'Intended Audience :: Telecommunications Industry',
         'License :: OSI Approved :: MIT License',
         'Operating System :: MacOS :: MacOS X',
         'Operating System :: POSIX',
@@ -44,9 +46,12 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
-        'Topic :: Utilities',
-        'Topic :: System :: Distributed Computing',
+        'Topic :: Communications',
+        'Topic :: Scientific/Engineering :: Atmospheric Science',
+        'Topic :: Scientific/Engineering :: GIS',
         'Topic :: Software Development',
+        'Topic :: System :: Distributed Computing',
+        'Topic :: Utilities',
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
Hi Fabien,

thanks for your suggestion at https://github.com/metwork-framework/cronwrapper/issues/16#issuecomment-772273810 to just use `cron-wrapper` as a name. I like it. This patch prepares everything on this matter. If you also like it, after integrating it, you will just have to
- rename the repository on GitHub to `cron-wrapper` for the sake of completeness
- cut the `0.1.0` release after adjusting the release date within `CHANGELOG.md`
- publish the package to PyPI

With kind regards,
Andreas.
